### PR TITLE
Fixed a couple python 3 compatibility issues

### DIFF
--- a/rpmfile/__init__.py
+++ b/rpmfile/__init__.py
@@ -38,7 +38,7 @@ class RPMInfo(object):
 
     @classmethod
     def _read(cls, magic, fileobj):
-        if magic == '070701':
+        if magic == b'070701':
             return cls._read_new(fileobj, magic=magic)
         else:
             raise Exception('bad magic number %r' % magic)
@@ -51,7 +51,7 @@ class RPMInfo(object):
         d = coder.unpack_from(fileobj.read(coder.size))
 
         namesize = int(d[11], 16)
-        name = fileobj.read(namesize)[:-1]
+        name = fileobj.read(namesize)[:-1].decode('utf-8')
         fileobj.seek(pad(fileobj), 1)
         file_start = fileobj.tell()
         file_size = int(d[6], 16)
@@ -111,7 +111,7 @@ class RPMFile(object):
             g = self.gzip_file
             magic = g.read(2)
             while magic:
-                if magic == '07':
+                if magic == b'07':
                     magic += g.read(4)
                     member = RPMInfo._read(magic, g)
 


### PR DESCRIPTION
Trying to get members doesn't work in python 3 because there are a couple of byte to string comparisons related to magic numbers and member names.