### PR TITLE
Resolves #21 to properly let context manager autoclose RPM file

### DIFF
--- a/rpmfile/__init__.py
+++ b/rpmfile/__init__.py
@@ -84,7 +84,7 @@ class RPMFile(object):
             raise NotImplementedError("currently the only supported mode is 'rb'")
         self._fileobj = fileobj or io.open(name, mode)
         self._header_range, self._headers = get_headers(self._fileobj)
-        self._ownes_fd = fileobj is not None
+        self._ownes_fd = fileobj is None
 
     @property
     def data_offset(self):


### PR DESCRIPTION
I wasn't sure what download link would be best for a regular rpm file, but we can substitute any non lzma rpm into the `@download` URL in the `test_extract.py`.