### PR TITLE
Version 0.1.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 40
+      matrix:
+        python-version: [2.7, 3.5, 3.6]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test
+      run: |
+        python setup.py test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 40
       matrix:
-        python-version: [2.7, 3.5, 3.6]
+        python-version: [2.7, 3.5, 3.6, 3.7]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 40
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
-  - "3.5"
-  - "3.6"
 script:
   - python setup.py test

--- a/rpmfile/headers.py
+++ b/rpmfile/headers.py
@@ -91,6 +91,7 @@ tags = {'signature': 267
 
     , 'authors':1081
     , 'comments':1082
+    , 'obsoletes':1090
 
 }
 

--- a/rpmfile/headers.py
+++ b/rpmfile/headers.py
@@ -94,7 +94,7 @@ tags = {'signature': 267
 
 }
 
-rtags = {value:key for (key, value) in tags.items()}
+rtags = dict([(value, key) for (key, value) in tags.items()])
 
 
 def extract_string(offset, count, store):

--- a/rpmfile/io_extra.py
+++ b/rpmfile/io_extra.py
@@ -34,6 +34,15 @@ class _SubFile(object):
             self._size = size
         self._pos = 0
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *excinfo):
+        pass
+
+    def close(self):
+        pass
+
     def __getattr__(self, attr):
         return getattr(self._fileobj, attr)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 setup(
     name='rpmfile',
     description='Read rpm archive files',
-    version="0.1.5",
+    version="0.1.6",
     author='Sean Ross-Ross',
     author_email='srossross@gmail.com',
     url='https://github.com/srossross/rpmfile',

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,17 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(),
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -63,10 +63,9 @@ class TempDirTest(unittest.TestCase):
             members = list(rpm.getmembers())
             self.assertEqual(len(members), 1)
 
-            fd = rpm.extractfile('./usr/bin/sudo')
-
-            calculated = hashlib.md5(fd.read()).hexdigest()
-            self.assertEqual(calculated, 'a208f3d9170ecfa69a0f4ccc78d2f8f6')
+            with rpm.extractfile('./usr/bin/sudo') as fd:
+                calculated = hashlib.md5(fd.read()).hexdigest()
+                self.assertEqual(calculated, 'a208f3d9170ecfa69a0f4ccc78d2f8f6')
 
 
     @download('https://download.fedoraproject.org/pub/fedora/linux/releases/30/Everything/source/tree/Packages/r/rpm-4.14.2.1-4.fc30.1.src.rpm', 'sample.rpm')
@@ -83,6 +82,18 @@ class TempDirTest(unittest.TestCase):
 
             members = list(rpm.getmembers())
             self.assertEqual(len(members), 13)
+
+            # Test that subfile does not close parent file by calling close and
+            # then extractfile again
+            fd = rpm.extractfile('rpm-4.13.90-ldflags.patch')
+            calculated = hashlib.md5(fd.read()).hexdigest()
+            self.assertEqual(calculated, '4841553ad9276fffd83df33643839a57')
+            fd.close()
+
+            fd = rpm.extractfile('rpm.spec')
+            calculated = hashlib.md5(fd.read()).hexdigest()
+            self.assertEqual(calculated, 'ed96e23cf7f8dd17c459e0dd4618888c')
+            fd.close()
 
         # Test that RPMFile owned file descriptor and that underlying file is really closed
         self.assertTrue(rpm_ref._fileobj.closed)


### PR DESCRIPTION
- Moved some of the testing to GitHub Actions
  - Faster response time than travis
- Include changes from #24 (ping @bubalazi)
  - travis no longer supports Python 2.6 so that was not carried over
  - Added classifiers as recommend by @fruch
- Added a test to verify that issue #19 is fixed
- Fixed an issue in 5e8d151 where calling `extractfile` again after calling close on a subfile returned by a previous call to `extractfile` caused an [ioerror](https://github.com/pdxjohnny/rpmfile/commit/aafc7fc8351b2baad13912d80404231002375e1c/checks/369434660/logs) ([more logs](https://github.com/pdxjohnny/rpmfile/runs/369434676))
- Bumped version to 0.1.6 for release on PyPi