### PR TITLE
cli: Add info option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ curl -sfL 'https://example.com/some.rpm.gz' | gzip -d - | rpmfile -xvC /tmp -
 /tmp/path/to/file
 ```
 
+Display RPM information (similar to command `rpm -qip` in Linux)
+
+```conosle
+curl -sfL 'https://example.com/some.rpm.gz' |gzip -d - | rpmfile -i -
+Name        : something
+Version     : 1.02
+Release     : 1
+Architecture: noarch
+Group       : default
+Size        : 1234
+License     : BSD
+Signature   : None
+Source RPM  : some.src.rpm
+Build Date  : Tue Apr  9 08:55:16 2019
+Build Host  : demo
+URL         : http://example.com/some
+Summary     : Example of something
+Description : 
+The description of something.
+It can display more than one line.
+```
+
+
 ## Classes
 
 * rpmfile.RPMFile: The RPMFile object provides an interface to a RPM archive

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -97,7 +97,7 @@ def main(*argv):
                 if isinstance(value, bytes):
                     value = value.decode()
                 if header == "buildtime":
-                    value = datetime.fromtimestamp(value)
+                    value = datetime.fromtimestamp(value).strftime("%c")
                 if header == "description":
                     value = "\n" + value
                 line = "%s: %s" % (headers_titles.get(header).ljust(12),value)

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -100,7 +100,7 @@ def main(*argv):
                     value = datetime.fromtimestamp(value).strftime("%c")
                 if header == "description":
                     value = "\n" + value
-                line = "%s: %s" % (headers_titles.get(header).ljust(12),value)
+                line = "%s: %s" % (headers_titles.get(header).ljust(12), value)
                 print(line)
                 output["info"] += line + "\n"
     elif args.extract:

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -74,32 +74,35 @@ def main(*argv):
                 print(rpminfo.name)
                 output["list"].append(rpminfo.name.split("/"))
     elif args.info:
+        output["info"] = ""
         with rpmfile.open(fileobj=buf) as rpm:
             headers_titles = {
-                'name': 'Name',
-                'version': 'Version',
-                'release': 'Release',
-                'arch': 'Architecture',
-                'group': 'Group',
-                'size': 'Size',
-                'copyright': 'License',
-                'signature': 'Signature',
-                'sourcerpm': 'Source RPM',
-                'buildtime': 'Build Date',
-                'buildhost': 'Build Host',
-                'url': 'URL',
-                'summary': 'Summary',
-                'description': 'Description',
+                "name": "Name",
+                "version": "Version",
+                "release": "Release",
+                "arch": "Architecture",
+                "group": "Group",
+                "size": "Size",
+                "copyright": "License",
+                "signature": "Signature",
+                "sourcerpm": "Source RPM",
+                "buildtime": "Build Date",
+                "buildhost": "Build Host",
+                "url": "URL",
+                "summary": "Summary",
+                "description": "Description",
             }
             for header in headers_titles:
                 value = rpm.headers.get(header)
                 if isinstance(value, bytes):
                     value = value.decode()
-                if header == 'buildtime':
+                if header == "buildtime":
                     value = datetime.fromtimestamp(value)
-                if header == 'description':
-                    value = '\n' + value
-                print('%s: %s' % (headers_titles.get(header).ljust(12),value))
+                if header == "description":
+                    value = "\n" + value
+                line = "%s: %s" % (headers_titles.get(header).ljust(12),value)
+                print(line)
+                output["info"] += line + "\n"
     elif args.extract:
         output["extracted"] = []
         dest = os.path.abspath(args.dest)

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from datetime import datetime
 import os
 import io
 import sys
@@ -38,6 +39,13 @@ def main(*argv):
         help="List files in RPM without extracting",
     )
     parser.add_argument(
+        "-i",
+        "--info",
+        dest="info",
+        action="store_true",
+        help="Display RPM information without extracting",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         dest="verbose",
@@ -65,6 +73,33 @@ def main(*argv):
             for rpminfo in rpm.getmembers():
                 print(rpminfo.name)
                 output["list"].append(rpminfo.name.split("/"))
+    elif args.info:
+        with rpmfile.open(fileobj=buf) as rpm:
+            headers_titles = {
+                'name': 'Name',
+                'version': 'Version',
+                'release': 'Release',
+                'arch': 'Architecture',
+                'group': 'Group',
+                'size': 'Size',
+                'copyright': 'License',
+                'signature': 'Signature',
+                'sourcerpm': 'Source RPM',
+                'buildtime': 'Build Date',
+                'buildhost': 'Build Host',
+                'url': 'URL',
+                'summary': 'Summary',
+                'description': 'Description',
+            }
+            for header in headers_titles:
+                value = rpm.headers.get(header)
+                if isinstance(value, bytes):
+                    value = value.decode()
+                if header == 'buildtime':
+                    value = datetime.fromtimestamp(value)
+                if header == 'description':
+                    value = '\n' + value
+                print('%s: %s' % (headers_titles.get(header).ljust(12),value))
     elif args.extract:
         output["extracted"] = []
         dest = os.path.abspath(args.dest)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import time
 import unittest
 
 from rpmfile.cli import main
@@ -21,7 +22,7 @@ class TempCLI(unittest.TestCase):
         "License     : BSD\n"
         "Signature   : None\n"
         "Source RPM  : gopacket-license-2019_04_08T07_36_42Z-1.src.rpm\n"
-        "Build Date  : 2019-04-09 15:55:16\n"
+        "Build Date  : Tue Apr  9 08:55:16 2019\n"
         "Build Host  : jenkins-slave-fat-cloud-nlbzt\n"
         "URL         : http://example.com/no-uri-given\n"
         "Summary     : License for gopacket-license\n"
@@ -33,6 +34,9 @@ class TempCLI(unittest.TestCase):
         cls.prevdir = os.getcwd()
         cls.tempdir = tempfile.mkdtemp()
         os.chdir(cls.tempdir)
+        os.environ["LC_ALL"] = "C"
+        os.environ["TZ"] = "UTC"
+        time.tzset()
 
     def tearDown(cls):
         shutil.rmtree(cls.tempdir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,23 @@ from .test_extract import download
 class TempCLI(unittest.TestCase):
     GOPACKET_LICENSE_DIRS = [".", "usr", "share", "doc", "gopacket-license"]
     GOPACKET_LICENSE_FILES = ["AUTHORS", "LICENSE"]
+    GOPACKET_LICENSE_INFO = (
+        "Name        : gopacket-license\n"
+        "Version     : 2019_04_08T07_36_42Z\n"
+        "Release     : 1\n"
+        "Architecture: noarch\n"
+        "Group       : default\n"
+        "Size        : 3223\n"
+        "License     : BSD\n"
+        "Signature   : None\n"
+        "Source RPM  : gopacket-license-2019_04_08T07_36_42Z-1.src.rpm\n"
+        "Build Date  : 2019-04-09 15:55:16\n"
+        "Build Host  : jenkins-slave-fat-cloud-nlbzt\n"
+        "URL         : http://example.com/no-uri-given\n"
+        "Summary     : License for gopacket-license\n"
+        "Description : \n"
+        "License for gopacket-license\n"
+    )
 
     def setUp(cls):
         cls.prevdir = os.getcwd()
@@ -52,3 +69,13 @@ class TempCLI(unittest.TestCase):
         self.assertEqual(len(output["list"]), len(self.GOPACKET_LICENSE_FILES))
         for filename in self.GOPACKET_LICENSE_FILES:
             self.assertIn(self.GOPACKET_LICENSE_DIRS + [filename], output["list"])
+
+    @download(
+        "https://github.com/srossross/rpmfile/files/3150016/gopacket-license.noarch.rpm.gz",
+        "gopacket.rpm",
+    )
+    def test_info(self, rpmpath):
+        """That the command line get RPM infomation correctly"""
+        _args, output = main("-i", rpmpath)
+        self.assertEqual(output["info"], self.GOPACKET_LICENSE_INFO)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,4 +82,3 @@ class TempCLI(unittest.TestCase):
         """That the command line get RPM infomation correctly"""
         _args, output = main("-i", rpmpath)
         self.assertEqual(output["info"], self.GOPACKET_LICENSE_INFO)
-


### PR DESCRIPTION
Add info option to the cli with output similar to the output from command `rpm -qip <rpmfile.rpm>`. 

e.g.

```console
rpmfile -i ~/rpmbuild/RPMS/x86_64/nim-1.2.12-1.1.x86_64.rpm
Name        : nim
Version     : 1.2.12
Release     : 1.1
Architecture: x86_64
Group       : Development/Languages/Other
Size        : 18693616
License     : MIT
Signature   : None
Source RPM  : nim-1.2.12-1.1.src.rpm
Build Date  : 2021-04-21 19:00:00
Build Host  : DS9
URL         : https://nim-lang.org/
Summary     : A statically typed, imperative programming language
Description :
Nim is a statically typed, imperative programming language.

Beneath a infix/indentation-based syntax with a (AST-based) macro
system lies a semantic model that supports a soft realtime GC on
thread local heaps. Asynchronous message passing is used between
threads. An unsafe shared memory heap is also provided for the
increased efficiency that results from that model.
```