### PR TITLE
Fix rpmfile fails to load localized RPM headers

### DIFF
--- a/rpmfile/headers.py
+++ b/rpmfile/headers.py
@@ -312,6 +312,8 @@ rtags = dict([(value, key) for (key, value) in tags.items()])
 
 
 def extract_string(offset, count, store):
+    if count > 1:
+        return extract_array(offset, count, store)
     assert count == 1
     idx = store[offset:].index(b"\x00")
     return store[offset : offset + idx]


### PR DESCRIPTION
https://github.com/srossross/rpmfile/issues/6
Return an array, and allow the user to deal with the issue.
There should not be any compatability options as we are the first to
use the library.
