### PR TITLE
Fixing incorrect parsing of first headers block (a.k.a. "signature headers")

### DIFF
--- a/rpmfile/headers.py
+++ b/rpmfile/headers.py
@@ -16,16 +16,16 @@ sigtags = {
     "lemd5_1": 1001,
     "pgp": 1002,
     "lemd5_2": 1003,
-    "sigmd5": 1004,  #md5 in C code but collides with md5 here
+    "sigmd5": 1004,  # md5 in C code but collides with md5 here
     "gpg": 1005,
     "pgp5": 1006,
     "payloadsize": 1007,
     "reservedspace": 1008,
     "badsha1_1": 264,
-    "badsha1_2": 265, 
+    "badsha1_2": 265,
     "signature": 267,
     "rsaheader": 268,
-    "md5": 269,  #sha1header in C code
+    "md5": 269,  # sha1header in C code
     "longsigsize": 270,
     "longarchivesize": 271,
     "sha256": 273,
@@ -52,9 +52,9 @@ tags = {
     "badsha1_1": 264,
     "badsha1_2": 265,
     "pubkeys": 266,
-    "signature": 267, #dsaheader in C code
+    "signature": 267,  # dsaheader in C code
     "rsaheader": 268,
-    "md5": 269,  #sha1header in C code
+    "md5": 269,  # sha1header in C code
     "longsigsize": 270,
     "longarchivesize": 271,
     "sha256": 273,
@@ -461,9 +461,9 @@ def get_headers(fileobj):
     data = fileobj.read(lead.size)
     value = lead.unpack(data)
 
-    #signature header
+    # signature header
     first_range, first_headers = _readheader(fileobj, True)
-    #main header
+    # main header
     second_range, second_headers = _readheader(fileobj, False)
 
     first_headers.update(second_headers)


### PR DESCRIPTION
The first set of headers is actually "signature headers" which _have somewhat different and conflicting set of key values_ than the main headers block.
The current way of parsing results in the second set overwriting unrelated keys from the first one.

You can see the "authoritative" procedure for parsing them by following the code at:
https://github.com/rpm-software-management/rpm/blob/d1075106bb315913574e1acac921058d23dd5130/tools/rpmdump.c#L205

Additionally I added some newer main tags that were previously not handled. You can see the current set of main and signature tags conveniently at
http://ftp.rpm.org/api/4.19.0/rpmtag_8h.html