### PR TITLE
feat: extend rpmfile by mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Style
       if: ${{ matrix.python-version == '3.14' }}
       run: |
-        pip install -U black==23.1.0
+        pip install -U black==26.3.1
         black -t py37 --check .
     - name: Package
       run: |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The [black](https://github.com/psf/black) formater should be used on all files
 before submitting a contribution. Version 19.10b0.
 
 ```console
-$ pip install black==19.10b0
+$ pip install black==26.3.1
 $ black .
 ```
 

--- a/rpmfile/__init__.py
+++ b/rpmfile/__init__.py
@@ -44,12 +44,13 @@ class RPMInfo(object):
 
     _new_coder = struct.Struct(b"8s8s8s8s8s8s8s8s8s8s8s8s8s")
 
-    def __init__(self, name, file_start, file_size, initial_offset, isdir):
+    def __init__(self, name, file_start, file_size, initial_offset, isdir, mode):
         self.name = name
         self.file_start = file_start
         self.size = file_size
         self.initial_offset = initial_offset
         self._isdir = isdir
+        self.mode = mode
 
     @property
     def isdir(self):
@@ -82,7 +83,9 @@ class RPMInfo(object):
         # https://www.mankier.com/5/cpio under Old Binary Format mode bits
         mode = int(d[1], 16)
         isdir = mode & int("0040000", 8)
-        return cls(name, file_start, file_size, initial_offset, isdir)
+        return cls(
+            name, file_start, file_size, initial_offset, isdir, mode & int("777", 8)
+        )
 
 
 class RPMFile(object):
@@ -172,7 +175,7 @@ class RPMFile(object):
         """
         if not isinstance(member, RPMInfo):
             member = self.getmember(member)
-        return _SubFile(self.data_file, member.file_start, member.size)
+        return _SubFile(self.data_file, member.file_start, member.size, member.mode)
 
     _data_file = None
 

--- a/rpmfile/__init__.py
+++ b/rpmfile/__init__.py
@@ -44,7 +44,9 @@ class RPMInfo(object):
 
     _new_coder = struct.Struct(b"8s8s8s8s8s8s8s8s8s8s8s8s8s")
 
-    def __init__(self, name, file_start, file_size, initial_offset, isdir, issymlink, mode):
+    def __init__(
+        self, name, file_start, file_size, initial_offset, isdir, issymlink, mode
+    ):
         self.name = name
         self.file_start = file_start
         self.size = file_size

--- a/rpmfile/__init__.py
+++ b/rpmfile/__init__.py
@@ -100,7 +100,7 @@ class RPMInfo(object):
             initial_offset,
             isdir,
             issymlink,
-            mode & int("777", 8)
+            mode & 0o777,
         )
 
 

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -127,6 +127,7 @@ def main(*argv):
                         outfile.write(rpmfileobj.read())
                     finally:
                         outfile.close()
+                        os.chmod(target, rpmfileobj.mode)
                     if args.verbose:
                         print(target)
                     output["extracted"].append(rpminfo.name.split("/"))

--- a/rpmfile/cli.py
+++ b/rpmfile/cli.py
@@ -139,10 +139,10 @@ def main(*argv):
                     else:
                         outfile = open(target, "wb")
                         try:
+                            os.fchmod(outfile.fileno(), rpmfileobj.mode)
                             shutil.copyfileobj(rpmfileobj, outfile)
                         finally:
                             outfile.close()
-                            os.chmod(target, rpmfileobj.mode)
                     if args.verbose:
                         print(target)
                     output["extracted"].append(rpminfo.name.split("/"))

--- a/rpmfile/headers.py
+++ b/rpmfile/headers.py
@@ -3,6 +3,7 @@ Created on Jan 10, 2014
 
 @author: sean
 """
+
 from __future__ import print_function, unicode_literals, absolute_import
 import sys
 import struct

--- a/rpmfile/io_extra.py
+++ b/rpmfile/io_extra.py
@@ -28,7 +28,7 @@ class _SubFile(object):
     object.
     """
 
-    def __init__(self, fileobj, start=0, size=None):
+    def __init__(self, fileobj, start=0, size=None, mode=None):
         self._fileobj = fileobj
         self._start = start
         if size is None:
@@ -37,6 +37,7 @@ class _SubFile(object):
             self._size = pos - start
         else:
             self._size = size
+        self._mode = mode
         self._pos = 0
 
     def __enter__(self):
@@ -97,3 +98,7 @@ class _SubFile(object):
             yield line
             line = self.readline(n)
             n -= len(line)
+
+    @property
+    def mode(self):
+        return self._mode

--- a/rpmfile/io_extra.py
+++ b/rpmfile/io_extra.py
@@ -3,6 +3,7 @@ Created on Jan 11, 2014
 
 @author: sean
 """
+
 import io
 
 

--- a/rpmfile/io_extra.py
+++ b/rpmfile/io_extra.py
@@ -28,7 +28,7 @@ class _SubFile(object):
     object.
     """
 
-    def __init__(self, fileobj, start=0, size=None, mode=None):
+    def __init__(self, fileobj, start=0, size=None, mode="r"):
         self._fileobj = fileobj
         self._start = start
         if size is None:

--- a/rpmfile/rpmdefs.py
+++ b/rpmfile/rpmdefs.py
@@ -6,6 +6,7 @@ rpm definitions
 
 Mario Morgado (BSD) https://github.com/mjvm/pyrpm
 """
+
 __revision__ = "$Rev$"[6:-2]
 
 RPM_LEAD_MAGIC_NUMBER = "\xed\xab\xee\xdb"

--- a/tests/test_subfile.py
+++ b/tests/test_subfile.py
@@ -3,6 +3,7 @@ Created on Jan 11, 2014
 
 @author: sean
 """
+
 import unittest
 
 import rpmfile


### PR DESCRIPTION
The mode is needed to keep the permissions of the extracted file in the file system. Most important are the executable flags which are currently gone.
Now the rpmfile -x archive.rpm now preserves the permissions, especially the executable flags which were gone before.